### PR TITLE
refactor: check signature separately from running function

### DIFF
--- a/src/caskade/decorators.py
+++ b/src/caskade/decorators.py
@@ -3,6 +3,7 @@ import functools
 from contextlib import ExitStack
 
 from .context import ActiveContext, OverrideParam
+from .param import Param
 
 __all__ = ("forward",)
 
@@ -55,8 +56,10 @@ def forward(method):
             with ExitStack() as stack:
                 # User override of parameters for single function call
                 used_kwargs = []
-                for kwarg, kval in kwargs.items():
-                    for cname, cval in self.children.items():
+                for cname, cval in self.children.items():
+                    if not isinstance(cval, Param):
+                        continue
+                    for kwarg, kval in kwargs.items():
                         if kwarg == cname:
                             stack.enter_context(OverrideParam(cval, kval))
                             used_kwargs.append(kwarg)

--- a/src/caskade/module.py
+++ b/src/caskade/module.py
@@ -459,11 +459,13 @@ class Module(Node):
             if isinstance(value, Node):
                 self.link(key, value)
             elif isinstance(value, list):
-                if all(isinstance(v, Node) for v in value):
-                    self.link(key, NodeList(value))
+                if len(value) > 0 and all(isinstance(v, Node) for v in value):
+                    value = NodeList(value)
+                    self.link(key, value)
             elif isinstance(value, tuple) and key not in self._special_tuples:
-                if all(isinstance(v, Node) for v in value):
-                    self.link(key, NodeTuple(value))
+                if len(value) > 0 and all(isinstance(v, Node) for v in value):
+                    value = NodeTuple(value)
+                    self.link(key, value)
         except AttributeError:
             pass
         super().__setattr__(key, value)


### PR DESCRIPTION
In the `forward` decorator, when extracting the params the decorator must check the signature of the function to see if the user passed an empty params argument. This check is now performed without running the function. This means that any `TypeError` errors that get thrown by the function wont accidentally get caught.