### PR TITLE
Change behaviour of full valid to act as simple clip function

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,7 +74,6 @@ jobs:
           echo "=== Testing wheel file ==="
           # Install wheel to get dependencies and check import
           python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre caskade
-          pip install torch numpy
           python -c "import caskade; print(caskade.__version__); caskade.test()"
           echo "=== Done testing wheel file ==="
 
@@ -82,7 +81,6 @@ jobs:
           # Install tar gz and check import
           python -m pip uninstall --yes caskade
           python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre --no-binary=:all: caskade
-          pip install torch numpy
           python -c "import caskade; print(caskade.__version__); caskade.test()"
           echo "=== Done testing source tar file ==="
 

--- a/docs/source/notebooks/AdvancedGuide.ipynb
+++ b/docs/source/notebooks/AdvancedGuide.ipynb
@@ -226,7 +226,10 @@
     "G.phi.cyclic = True\n",
     "\n",
     "# Standard deviation (sigma) should be strictly positive\n",
-    "G.sigma.valid = (0, None)"
+    "G.sigma.valid = (0, None)\n",
+    "\n",
+    "# Typically you actually set the valid range when making a parameter\n",
+    "p = ck.Param(\"p\", 0.5, valid=(0, 1))"
    ]
   },
   {

--- a/docs/source/notebooks/AdvancedGuide.ipynb
+++ b/docs/source/notebooks/AdvancedGuide.ipynb
@@ -202,6 +202,93 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Set valid range for a parameter\n",
+    "\n",
+    "Not all parameters should be allowed to explore any real number in $(-\\infty, \\infty)$. So caskade provides a simple system to record and sometimes enforce the valid range for a given parameter. The valid range is simply a tuple of two values that tell caskade what values to expect for that parameter. If you provide ``param.valid = (0, None)`` then the value must be strictly greater than zero. If you provide ``param.valid = (None, 1)`` then the value must be strictly less than one. If you provide ``param.valid = (0, 1)`` then the value can be anything from zero to one (inclusive). If you set a param to be cyclic via ``param.cyclic = True`` then it must have a two sided valid range and in that case a value which passes outside the valid range is wrapped around via modulo arithmetic.\n",
+    "\n",
+    "**Note:** Keep in mind that the one sided limits are exclusive (value cannot equal the boundary), while the two sided limits are inclusive (the value can equal the boundary values). This is for numerical stability reasons both in the forward calculations and in passing gradients. Internally, the one sided limits are enforced via a log/exp pair to transform between spaces, while the two sided limits are enforced via a gradient preserving value clip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make basic gaussian model\n",
+    "G = Gaussian(\"G\", x0=5, y0=5, q=0.5, phi=0.0, sigma=1.0, I0=1.0)\n",
+    "\n",
+    "# Axis ratio (q) should be restricted to (0, 1), but the 0 boundary is unstable so we add an epsilon to the lower bound\n",
+    "G.q.valid = (1e-6, 1.0)\n",
+    "\n",
+    "# Position angle (phi) should be restricted to (-pi, pi), and is cyclic\n",
+    "G.phi.valid = (-np.pi, np.pi)\n",
+    "G.phi.cyclic = True\n",
+    "\n",
+    "# Standard deviation (sigma) should be strictly positive\n",
+    "G.sigma.valid = (0, None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets see what happens when we set an invalid value for the axis ratio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.q = -0.1  # Invalid, below lower bound, throws warning\n",
+    "print(\"q:\", G.q.npvalue)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we were still allowed to set the invalid value, we were only given a warning. in this sense, caskade is quite permissive, but sometimes you will want to guarantee that values remain in a valid range regardless of what the user provides. That is a case for the ``ValidContext`` which intercepts value setting at the module level and ensures values remain in their valid range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G.q = 0.5  # Back to valid value\n",
+    "G.q.to_dynamic()\n",
+    "G.sigma.to_dynamic()\n",
+    "\n",
+    "print(\"Outside valid context, get_values: \", G.get_values(\"dict\"))\n",
+    "with ck.ValidContext(G):\n",
+    "    # Inside valid context, get_values/set_values works a bit differently\n",
+    "    params = G.get_values(\"dict\")\n",
+    "    print(\"In valid context, get_values: \", params)\n",
+    "\n",
+    "    params[\"q\"] = torch.tensor(-0.1)  # Change q to invalid value?\n",
+    "    params[\"sigma\"] = torch.tensor(-1.0)  # Change sigma to invalid value?\n",
+    "\n",
+    "    G.set_values(params)  # Set values, will compress to valid range\n",
+    "    print(\"After set_values, q:\", G.q.npvalue, \"sigma:\", G.sigma.npvalue)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we call ``Module.get_values()`` inside the ``ValidContext``, the ``q`` value which has a double valid range is returned normally, but the ``sigma`` value is converted to log space ($\\log(1.0) = 0.0$). When we call ``Module.set_values(params)`` with our updated parameters, the ``q`` value is clipped back to the valid range, while the ``sigma`` value is converted from log space to linear space ($e^{-1.0} = 0.3678...$).\n",
+    "\n",
+    "The valid context can be super useful for sampling/optimization. If you use ``x0 = Module.get_values()`` inside a ``ValidContext`` then run a sampler/optimizer it will be able to start from ``x0`` and explore the parameter space without needing to worry about accidentally falling out of the valid ranges and crashing your code. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Call function with internally modified param value\n",
     "\n",
     "A caskade simulator often is build of nested modules that call each others functions. Sometimes one may wish to call a function but with a different value for one of the Params than what has been given in the input (for example when computing a reference for comparison). Here we will show how to do this kind of local Param modification. This is also covered in [Ways of accessing Param values](#ways-of-accessing-param-values)."

--- a/src/caskade/backend.py
+++ b/src/caskade/backend.py
@@ -312,12 +312,12 @@ class Backend:
     def _ste_clip_torch(self, array, min_val, max_val):
         """Clip function such that gradients are preserved at the boundaries."""
         clipped = self.module.clamp(array, min=min_val, max=max_val)
-        return array + (clipped - array).detach()
+        return clipped.detach() + (array - array.detach())
 
     def _ste_clip_jax(self, array, min_val, max_val):
         """Clip function such that gradients are preserved at the boundaries."""
         clipped = self.module.clip(array, min=min_val, max=max_val)
-        return array + self.jax.lax.stop_gradient(clipped - array)
+        return self.jax.lax.stop_gradient(clipped) + (array - self.jax.lax.stop_gradient(array))
 
     def _ste_clip_numpy(self, array, min_val, max_val):
         """Standard clip function of numpy."""

--- a/src/caskade/backend.py
+++ b/src/caskade/backend.py
@@ -102,8 +102,6 @@ class Backend:
         self.as_array = self._as_array_torch
         self.to = self._to_torch
         self.to_numpy = self._to_numpy_torch
-        self.logit = self._logit_torch
-        self.sigmoid = self._sigmoid_torch
         self.ste_clip = self._ste_clip_torch
 
     def setup_jax(self):
@@ -118,8 +116,6 @@ class Backend:
         self.as_array = self._as_array_jax
         self.to = self._to_jax
         self.to_numpy = self._to_numpy_jax
-        self.logit = self._logit_jax
-        self.sigmoid = self._sigmoid_jax
         self.ste_clip = self._ste_clip_jax
 
     def setup_numpy(self):
@@ -133,8 +129,6 @@ class Backend:
         self.as_array = self._as_array_numpy
         self.to = self._to_numpy
         self.to_numpy = self._to_numpy_numpy
-        self.logit = self._logit_numpy
-        self.sigmoid = self._sigmoid_numpy
         self.ste_clip = self._ste_clip_numpy
 
     @property
@@ -315,33 +309,18 @@ class Backend:
         """
         return self.module.sum(array, axis=axis)
 
-    def _sigmoid_torch(self, array):
-        return self.module.sigmoid(array)
-
-    def _sigmoid_jax(self, array):
-        return self.jax.nn.sigmoid(array)
-
-    def _sigmoid_numpy(self, array):
-        return 1 / (1 + self.module.exp(-array))
-
-    def _logit_torch(self, array):
-        return self.module.logit(array)
-
-    def _logit_jax(self, array):
-        return self.jax.scipy.special.logit(array)
-
-    def _logit_numpy(self, array):
-        return np.log(array / (1 - array))
-
     def _ste_clip_torch(self, array, min_val, max_val):
+        """Clip function such that gradients are preserved at the boundaries."""
         clipped = self.module.clamp(array, min=min_val, max=max_val)
         return array + (clipped - array).detach()
 
     def _ste_clip_jax(self, array, min_val, max_val):
-        clipped = self.module.clip(array, a_min=min_val, a_max=max_val)
+        """Clip function such that gradients are preserved at the boundaries."""
+        clipped = self.module.clip(array, min=min_val, max=max_val)
         return array + self.jax.lax.stop_gradient(clipped - array)
 
     def _ste_clip_numpy(self, array, min_val, max_val):
+        """Standard clip function of numpy."""
         return np.clip(array, a_min=min_val, a_max=max_val)
 
 

--- a/src/caskade/backend.py
+++ b/src/caskade/backend.py
@@ -104,6 +104,7 @@ class Backend:
         self.to_numpy = self._to_numpy_torch
         self.logit = self._logit_torch
         self.sigmoid = self._sigmoid_torch
+        self.ste_clip = self._ste_clip_torch
 
     def setup_jax(self):
         self.jax = importlib.import_module("jax")
@@ -119,6 +120,7 @@ class Backend:
         self.to_numpy = self._to_numpy_jax
         self.logit = self._logit_jax
         self.sigmoid = self._sigmoid_jax
+        self.ste_clip = self._ste_clip_jax
 
     def setup_numpy(self):
         self.make_array = self._make_array_numpy
@@ -133,6 +135,7 @@ class Backend:
         self.to_numpy = self._to_numpy_numpy
         self.logit = self._logit_numpy
         self.sigmoid = self._sigmoid_numpy
+        self.ste_clip = self._ste_clip_numpy
 
     @property
     def array_type(self):
@@ -329,6 +332,17 @@ class Backend:
 
     def _logit_numpy(self, array):
         return np.log(array / (1 - array))
+
+    def _ste_clip_torch(self, array, min_val, max_val):
+        clipped = self.module.clamp(array, min=min_val, max=max_val)
+        return array + (clipped - array).detach()
+
+    def _ste_clip_jax(self, array, min_val, max_val):
+        clipped = self.module.clip(array, a_min=min_val, a_max=max_val)
+        return array + self.jax.lax.stop_gradient(clipped - array)
+
+    def _ste_clip_numpy(self, array, min_val, max_val):
+        return np.clip(array, a_min=min_val, a_max=max_val)
 
 
 #: Module-level :class:`Backend` instance used as the default entry point.

--- a/src/caskade/param.py
+++ b/src/caskade/param.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, Any, Iterable
+from typing import Optional, Union, Any, Iterable
 from warnings import warn
 from math import prod
 
@@ -332,8 +332,8 @@ class Param(Node):
                 )
 
         self.__value = value
-        self.is_valid()
         self.node_type = "static"
+        self.is_valid()
 
     def to_pointer(self, value, link=()):
         """Change this parameter to a pointer parameter.
@@ -793,10 +793,14 @@ class Param(Node):
             value = self.value
         if value is None:
             return True
-        if self.valid[0] is not None and backend.any(value < self.valid[0]):
+        if self.valid[0] is not None and self.valid[1] is not None:
+            if backend.any(value < self.valid[0]) or backend.any(value > self.valid[1]):
+                warn(InvalidValueWarning(self.name, value, self.valid))
+                return False
+        elif self.valid[0] is not None and backend.any(value <= self.valid[0]):
             warn(InvalidValueWarning(self.name, value, self.valid))
             return False
-        elif self.valid[1] is not None and backend.any(value > self.valid[1]):
+        elif self.valid[1] is not None and backend.any(value >= self.valid[1]):
             warn(InvalidValueWarning(self.name, value, self.valid))
             return False
         return True

--- a/src/caskade/param.py
+++ b/src/caskade/param.py
@@ -805,9 +805,6 @@ class Param(Node):
         return value
 
     def _to_valid_fullvalid(self, value: ArrayLike) -> ArrayLike:
-        value = (
-            backend.logit((value - self.valid[0]) / (self.valid[1] - self.valid[0])) + self.valid[0]
-        )
         return value
 
     def _to_valid_cyclic(self, value: ArrayLike) -> ArrayLike:
@@ -823,10 +820,7 @@ class Param(Node):
         return value
 
     def _from_valid_fullvalid(self, value: ArrayLike) -> ArrayLike:
-        value = (
-            backend.sigmoid(value - self.valid[0]) * (self.valid[1] - self.valid[0]) + self.valid[0]
-        )
-        return value
+        return backend.ste_clip(value, self.valid[0], self.valid[1])
 
     def _from_valid_cyclic(self, value: ArrayLike) -> ArrayLike:
         value = ((value - self.valid[0]) % (self.valid[1] - self.valid[0])) + self.valid[0]

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -4,11 +4,13 @@ import numpy as np
 from caskade import (
     Param,
     Module,
+    forward,
     ActiveStateError,
     ParamConfigurationError,
     ParamTypeError,
     InvalidValueWarning,
     ActiveContext,
+    ValidContext,
     backend,
 )
 
@@ -317,8 +319,10 @@ def test_valid():
     ), "from_valid should map to valid range"
 
     p.valid = (0, 1)
-    assert p.to_valid(v) != v, "valid value should change"
-    assert p.from_valid(v) != v, "valid value should change"
+    assert p.to_valid(v) == v, "valid value in range should not change"
+    assert p.from_valid(v) == v, "valid value in range should not change"
+    assert p.from_valid(v + 5) == 1.0, "valid value should be clamped to max"
+    assert p.from_valid(v - 5) == 0.0, "valid value should be clamped to min"
     assert backend.all(
         p.from_valid(backend.module.linspace(-1e4, 1e4, 101)) >= 0
     ), "from_valid should map to valid range"
@@ -352,6 +356,37 @@ def test_valid():
         p.valid = (0, None)
     with pytest.warns(InvalidValueWarning):
         p.valid = (None, -2)
+
+
+def test_full_valid_grad():
+    if backend.backend == "numpy":
+        pytest.skip("Numpy backend does not support gradients")
+
+    class DummyModule(Module):
+        def __init__(self):
+            super().__init__()
+            self.p = Param("test", 0.5, valid=(0, 1))
+
+        @forward
+        def forward(self):
+            return 2 * self.p.value**2
+
+    M = DummyModule()
+    with ValidContext(M):
+        params = M.get_values() * 10
+        if backend.backend == "jax":
+            grad = backend.jax.grad(M.forward)
+        elif backend.backend == "torch":
+            grad = backend.module.func.grad(M.forward)
+        assert np.all(
+            backend.to_numpy(params) > 1
+        ), "Params should be outside valid range for testing"
+        assert np.allclose(grad(params), 2.0), "Gradient should be 2.0, at high valid border"
+        params = -params
+        assert np.all(
+            backend.to_numpy(params) < 0
+        ), "Params should be outside valid range for testing"
+        assert np.allclose(grad(params), 0.0), "Gradient should be 0.0 at low valid border"
 
 
 def test_node_str():

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -365,15 +365,16 @@ def test_full_valid_grad():
     class DummyModule(Module):
         def __init__(self):
             super().__init__()
-            self.p = Param("test", 0.5, valid=(0, 1))
+            self.p = Param("test", 0.5, valid=(0, 1), dynamic=True)
 
         @forward
         def forward(self):
-            return 2 * self.p.value**2
+            return 2 * (self.p.value**2)
 
     M = DummyModule()
     with ValidContext(M):
         params = M.get_values() * 10
+        assert len(params) == 1, "There should be one parameter in the module"
         if backend.backend == "jax":
             grad = backend.jax.grad(M.forward)
         elif backend.backend == "torch":
@@ -381,7 +382,7 @@ def test_full_valid_grad():
         assert np.all(
             backend.to_numpy(params) > 1
         ), "Params should be outside valid range for testing"
-        assert np.allclose(grad(params), 2.0), "Gradient should be 2.0, at high valid border"
+        assert np.allclose(grad(params), 4.0), "Gradient should be 4.0, at high valid border"
         params = -params
         assert np.all(
             backend.to_numpy(params) < 0


### PR DESCRIPTION
Now the full valid case where a user provides both boundaries for the valid range of a parameter will act as a simple clip when going from valid to natural parameter space. One key change here is that the boundaries are now inclusive rather than exclusive. 